### PR TITLE
fix: provide default value in forRoot() method

### DIFF
--- a/projects/ngneat/dialog/src/lib/dialog.module.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.module.ts
@@ -22,7 +22,7 @@ const BuiltIns = [BaseDialogComponent, SuccessDialogComponent, ConfirmDialogComp
   exports: [DialogComponent, DialogCloseDirective]
 })
 export class DialogModule {
-  static forRoot(config?: Partial<GlobalDialogConfig>): ModuleWithProviders<DialogModule> {
+  static forRoot(config: Partial<GlobalDialogConfig> = {}): ModuleWithProviders<DialogModule> {
     return {
       ngModule: DialogModule,
       providers: [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, when using `DialogModule.forRoot()` without any parameters, the dialog pops pup but can't close, it get the following error message:

```
ERROR TypeError: Cannot read property 'onClose' of undefined
```

You can find a repro [here](https://stackblitz.com/edit/ngneat-dialog-onclose?file=src%2Fapp%2Fapp.module.ts).  When adding an empty object to `forRoot()`, it works as expected.

Issue Number: N/A

## What is the new behavior?

This patch adds a default empty object.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
	