### PR TITLE
fix(dialog-component): use appendChild instead of append (IE)

### DIFF
--- a/projects/ngneat/dialog/src/lib/dialog.component.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.component.ts
@@ -84,7 +84,7 @@ export class DialogComponent implements OnInit, OnDestroy {
     // something from the dialog component
     // for example, if `[dialogClose]` is used into a directive,
     // DialogRef will be getted from DialogService instead of DI
-    host.append(...this.nodes);
+    this.nodes.forEach(node => host.appendChild(node));
 
     if (config.windowClass) {
       host.classList.add(config.windowClass);
@@ -112,7 +112,7 @@ export class DialogComponent implements OnInit, OnDestroy {
 
     // `dialogElement` is resolvesd at this point
     // And here is where dialog finally will be placed
-    dialogElement.append(...this.nodes);
+    this.nodes.forEach(node => dialogElement.appendChild(node));
   }
 
   closeDialog() {

--- a/projects/ngneat/dialog/src/lib/dialog.service.spec.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.service.spec.ts
@@ -1,5 +1,4 @@
 import { ApplicationRef, ComponentFactoryResolver, TemplateRef, Injector, InjectionToken } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
 import { fakeAsync, tick } from '@angular/core/testing';
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator';
 import { timer } from 'rxjs';
@@ -16,7 +15,7 @@ class FakeFactoryResolver extends ComponentFactoryResolver {
     destroy: jasmine.createSpy(),
     hostView: {
       destroy: jasmine.createSpy(),
-      rootNodes: 'nodes 1'
+      rootNodes: [document.createTextNode('nodes 1')]
     },
     location: {
       nativeElement: 'fake 1'
@@ -27,7 +26,7 @@ class FakeFactoryResolver extends ComponentFactoryResolver {
     destroy: jasmine.createSpy(),
     hostView: {
       destroy: jasmine.createSpy(),
-      rootNodes: 'nodes 2'
+      rootNodes: [document.createTextNode('nodes 2')]
     },
     location: {
       nativeElement: 'fake 2'
@@ -45,7 +44,7 @@ class FakeTemplateRef extends TemplateRef<any> {
   elementRef = null;
 
   view = {
-    rootNodes: 'template nodes',
+    rootNodes: [document.createTextNode('template'), document.createTextNode(' nodes')],
     destroy: jasmine.createSpy()
   };
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

[`append` isn't supported by IE](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append#Browser_compatibility).

Issue Number: fixes #12

## What is the new behavior?
Use appendChild, well supported in IE

## Does this PR introduce a breaking change?
It shouldn't because every element of `rootNodes` is an Element instance

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
