### PR TITLE
fix: backdrop click

### DIFF
--- a/projects/ngneat/dialog/src/lib/dialog.component.spec.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.component.spec.ts
@@ -1,12 +1,11 @@
 import { Provider } from '@angular/core';
-import { Spectator, createComponentFactory, byText } from '@ngneat/spectator';
+import { byText, createComponentFactory, Spectator } from '@ngneat/spectator';
 import { Subject } from 'rxjs';
-
-import { DialogComponent } from './dialog.component';
-import { NODES_TO_INSERT, DIALOG_CONFIG } from './tokens';
-import { InternalDialogRef } from './dialog-ref';
-import { DialogDraggableDirective } from './draggable.directive';
 import { DialogConfig } from './config';
+import { InternalDialogRef } from './dialog-ref';
+import { DialogComponent } from './dialog.component';
+import { DialogDraggableDirective } from './draggable.directive';
+import { DIALOG_CONFIG, NODES_TO_INSERT } from './tokens';
 
 describe('DialogComponent', () => {
   const defaultConfig: Partial<DialogConfig> = {
@@ -99,7 +98,7 @@ describe('DialogComponent', () => {
         next: () => (backdropClicked = true)
       });
 
-      spectator.dispatchMouseEvent('.ngneat-dialog-backdrop', 'mouseup');
+      spectator.dispatchMouseEvent('.ngneat-dialog-backdrop', 'click');
 
       expect(backdropClicked).toBeTrue();
     });
@@ -118,7 +117,7 @@ describe('DialogComponent', () => {
         next: () => (backdropClicked = true)
       });
 
-      spectator.dispatchMouseEvent(document.body, 'mouseup');
+      spectator.dispatchMouseEvent(document.body, 'click');
 
       expect(backdropClicked).toBeTrue();
     });
@@ -142,15 +141,15 @@ describe('DialogComponent', () => {
     it('on click backdrop', () => {
       const { close } = spectator.get(InternalDialogRef);
 
-      spectator.dispatchMouseEvent('.ngneat-dialog-content', 'mouseup');
+      spectator.dispatchMouseEvent('.ngneat-dialog-content', 'click');
 
       expect(close).not.toHaveBeenCalled();
 
-      spectator.dispatchMouseEvent(document.body, 'mouseup');
+      spectator.dispatchMouseEvent(document.body, 'click');
 
       expect(close).not.toHaveBeenCalled();
 
-      spectator.dispatchMouseEvent('.ngneat-dialog-backdrop', 'mouseup');
+      spectator.dispatchMouseEvent('.ngneat-dialog-backdrop', 'click');
 
       expect(close).toHaveBeenCalled();
     });
@@ -170,15 +169,15 @@ describe('DialogComponent', () => {
     it('on click backdrop', () => {
       const { close: close } = spectator.get(InternalDialogRef);
 
-      spectator.dispatchMouseEvent('.ngneat-dialog-content', 'mouseup');
+      spectator.dispatchMouseEvent('.ngneat-dialog-content', 'click');
 
       expect(close).not.toHaveBeenCalled();
 
-      spectator.dispatchMouseEvent(document.body, 'mouseup');
+      spectator.dispatchMouseEvent(document.body, 'click');
 
       expect(close).not.toHaveBeenCalled();
 
-      spectator.dispatchMouseEvent('.ngneat-dialog-backdrop', 'mouseup');
+      spectator.dispatchMouseEvent('.ngneat-dialog-backdrop', 'click');
 
       expect(close).not.toHaveBeenCalled();
     });

--- a/projects/ngneat/dialog/src/lib/dialog.component.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.component.ts
@@ -1,12 +1,11 @@
-import { Component, ViewChild, ElementRef, Inject, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-import { fromEvent, Subject, merge } from 'rxjs';
+import { Component, ElementRef, Inject, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { fromEvent, merge, Subject } from 'rxjs';
 import { filter, takeUntil } from 'rxjs/operators';
-
-import { InternalDialogRef } from './dialog-ref';
 import { DialogConfig } from './config';
-import { DIALOG_CONFIG, NODES_TO_INSERT } from './tokens';
+import { InternalDialogRef } from './dialog-ref';
 import { coerceCssPixelValue } from './dialog.utils';
+import { DIALOG_CONFIG, NODES_TO_INSERT } from './tokens';
 
 @Component({
   selector: 'ngneat-dialog',
@@ -83,7 +82,7 @@ export class DialogComponent implements OnInit, OnDestroy {
     const backdrop = this.config.backdrop ? this.backdrop.nativeElement : this.document.body;
     const dialogElement = this.dialogElement.nativeElement;
 
-    const backdropClick$ = fromEvent<MouseEvent>(backdrop, 'mouseup').pipe(
+    const backdropClick$ = fromEvent<MouseEvent>(backdrop, 'click').pipe(
       filter(({ target }) => !dialogElement.contains(target as Element))
     );
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

In a dialog, if you are trying to select text, and your mouse extends beyond the content container, when you release the mouse button (mouseup), the dialog closes.  The click intent was inside the dialog, not on the backdrop, so I don't think a dialog should close.

Issue Number: N/A

## What is the new behavior?

This PR changes the MouseEvent to `click`.  The dialog would only close if you click on the backdrop.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
