### PR TITLE
fix(dialog-service): Remove 'ngneat-dialog-hidden' from body

### DIFF
--- a/projects/ngneat/dialog/src/lib/dialog.service.spec.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.service.spec.ts
@@ -55,7 +55,13 @@ describe('DialogService', () => {
   let service: DialogService;
   let fakeAppRef: ApplicationRef;
   let fakeFactory: FakeFactoryResolver;
-  let fakeDocument: { body: { appendChild: jasmine.Spy; removeChild: jasmine.Spy } };
+  let fakeDocument: {
+    body: {
+      appendChild: jasmine.Spy;
+      removeChild: jasmine.Spy;
+      classList: { add: jasmine.Spy; remove: jasmine.Spy }
+    }
+  };
 
   const createService = createServiceFactory({
     service: DialogService,
@@ -200,6 +206,46 @@ describe('DialogService', () => {
         $implicit: dialog,
         config: jasmine.objectContaining({ windowClass: 'custom-template' })
       });
+    });
+  });
+
+  describe('when nested', () => {
+    it('should open both', () => {
+      expect(service.open(new FakeTemplateRef())).toBeTruthy();
+      expect(service.open(new FakeTemplateRef())).toBeTruthy();
+    });
+
+    it('should add both dialogs to dialogs', () => {
+      const dialog1 = service.open(new FakeTemplateRef());
+      const dialog2 = service.open(new FakeTemplateRef());
+
+      expect(service.dialogs.length).toBe(2);
+      expect(service.dialogs).toContain(dialog1);
+      expect(service.dialogs).toContain(dialog2);
+    });
+
+    it('should add OVERFLOW_HIDDEN_CLASS to body only once', () => {
+      service.open(new FakeTemplateRef());
+      service.open(new FakeTemplateRef());
+
+      expect(fakeDocument.body.classList.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not remove OVERFLOW_HIDDEN_CLASS from when close one', () => {
+      const dialog1 = service.open(new FakeTemplateRef());
+      service.open(new FakeTemplateRef());
+
+      dialog1.close();
+      expect(fakeDocument.body.classList.remove).toHaveBeenCalledTimes(0);
+    });
+
+    it('should remove OVERFLOW_HIDDEN_CLASS from when close all', () => {
+      const dialog1 = service.open(new FakeTemplateRef());
+      const dialog2 = service.open(new FakeTemplateRef());
+
+      dialog1.close();
+      dialog2.close();
+      expect(fakeDocument.body.classList.remove).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/projects/ngneat/dialog/src/lib/dialog.service.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.service.ts
@@ -107,7 +107,9 @@ export class DialogService {
     this.throwIfIDAlreadyExists(configWithDefaults.id);
 
     this.dialogs.push(dialogRef);
-    this.document.body.classList.add(OVERFLOW_HIDDEN_CLASS);
+    if (this.dialogs.length === 1) {
+      this.document.body.classList.add(OVERFLOW_HIDDEN_CLASS);
+    }
 
     return componentOrTemplate instanceof TemplateRef
       ? this.openTemplate(componentOrTemplate, params)
@@ -191,7 +193,9 @@ export class DialogService {
 
       hooks.after.next(result);
       hooks.after.complete();
-      this.document.body.classList.remove(OVERFLOW_HIDDEN_CLASS);
+      if (this.dialogs.length === 0) {
+        this.document.body.classList.remove(OVERFLOW_HIDDEN_CLASS);
+      }
     };
 
     dialogRef.mutate({


### PR DESCRIPTION
fixes ngneat/dialog#26

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When nested dialog is closed, class 'ngneat-dialog-hidden' is removed from body.
Issue Number: 26

## What is the new behavior?
Class 'ngneat-dialog-hidden' is removed from body after last dialog was closed.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
