### PR TITLE
feat: allow multiple classes to be set from windowClass

### DIFF
--- a/projects/ngneat/dialog/src/lib/dialog.component.spec.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.component.spec.ts
@@ -215,4 +215,13 @@ describe('DialogComponent', () => {
     expect(host).toBeTruthy();
     expect(host).toBe(spectator.fixture.nativeElement);
   });
+
+  it('should set multiple classes from windowClass at host element', () => {
+    spectator = createComponent(withConfig({ windowClass: ' test-class-1 test-class-2 ' }));
+
+    const host = spectator.query('.test-class-1.test-class-2', { root: true });
+
+    expect(host).toBeTruthy();
+    expect(host).toBe(spectator.fixture.nativeElement);
+  });
 });

--- a/projects/ngneat/dialog/src/lib/dialog.component.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.component.ts
@@ -74,7 +74,8 @@ export class DialogComponent implements OnInit, OnDestroy {
     this.nodes.forEach(node => host.appendChild(node));
 
     if (config.windowClass) {
-      host.classList.add(...config.windowClass.split(/\s/).filter(x => x));
+      const classNames = config.windowClass.split(/\s/).filter(x => x);
+      classNames.forEach(name => host.classList.add(name));
     }
   }
 

--- a/projects/ngneat/dialog/src/lib/dialog.component.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.component.ts
@@ -74,7 +74,7 @@ export class DialogComponent implements OnInit, OnDestroy {
     this.nodes.forEach(node => host.appendChild(node));
 
     if (config.windowClass) {
-      host.classList.add(config.windowClass);
+      host.classList.add(...config.windowClass.split(/\s/).filter(x => x));
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When two classes added to `DialogConfig.windowClass` a
```DOMException: Failed to execute 'add' on 'DOMTokenList': The token provided ('center dialog-lg') contains HTML space characters, which are not valid in tokens.```
is thrown.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
All classes added to `DialogConfig.windowClass` will be added to host element.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
