### PR TITLE
feat: closeButton without backdrop click close

### DIFF
--- a/projects/ngneat/dialog/src/lib/dialog.component.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.component.ts
@@ -24,7 +24,7 @@ import { DIALOG_CONFIG, NODES_TO_INSERT } from './tokens';
           [dialogDragEnabled]="true"
           [dialogDragTarget]="dialog"
         ></div>
-        <div class="ngneat-close-dialog" *ngIf="config.enableClose && config.closeButton" (click)="closeDialog()">
+        <div class="ngneat-close-dialog" *ngIf="config.closeButton" (click)="closeDialog()">
           <svg viewBox="0 0 329.26933 329" xmlns="http://www.w3.org/2000/svg">
             <path
               fill="currentColor"


### PR DESCRIPTION
Allow users to keep close Button when they don't want backdrop click to close their dialog.

Closes https://github.com/ngneat/dialog/issues/30

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Now when you set `enableClose: false` you can not have X button, it is dependent on this flag.

Issue Number: 30

## What is the new behavior?

You can choose whether you want X button or not independently from `enableClose` flag just by setting `closeButton` flag. User might want to disable closing on the backdrop, but want X button on dialog.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
