### PR TITLE
fix: pass through offset parameters to resetDrag method

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ dialogRef.backdropClick$.subscribe(() => {
 });
 ```
 
-- `resetOffset` - A method that can be called to reset the offset of a dragged modal to reposition it in the middle of the screen. An offset can be given as the first parameter to position it different from the center:
+- `resetDrag` - A method that can be called to reset the dragged modal to the middle of the screen. An offset can be given as the first parameter to position it different from the center:
 
 ```ts
-dialogRef.resetOffset();
-dialogRef.resetOffset({ x: 100, y: 0 });
+dialogRef.resetDrag();
+dialogRef.resetDrag({ x: 100, y: 0 });
 ```
 
 - `beforeClose` - A guard that should return a `boolean`, an `observable`, or a `promise` indicating whether the modal can be closed:

--- a/projects/ngneat/dialog/src/lib/dialog-ref.ts
+++ b/projects/ngneat/dialog/src/lib/dialog-ref.ts
@@ -35,7 +35,7 @@ export class InternalDialogRef extends DialogRef {
   }
 
   onClose: (result?: unknown) => void;
-  onReset: () => void;
+  onReset: (offset?: DragOffset) => void;
 
   close(result?: unknown): void {
     this.canClose(result)
@@ -48,7 +48,7 @@ export class InternalDialogRef extends DialogRef {
   }
 
   resetDrag(offset?: DragOffset) {
-    this.onReset();
+    this.onReset(offset);
   }
 
   canClose(result: unknown): Observable<boolean> {

--- a/projects/ngneat/dialog/src/lib/dialog.service.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.service.ts
@@ -25,6 +25,7 @@ import {
   ExtractDialogRefResult,
   ExtractDialogResolvedRef
 } from './types';
+import { DragOffset } from './draggable.directive';
 
 interface OpenParams {
   config: DialogConfig;
@@ -202,8 +203,8 @@ export class DialogService {
       }
     };
 
-    const onReset = () => {
-      dialog.instance.reset();
+    const onReset = (offset?: DragOffset) => {
+      dialog.instance.reset(offset);
     };
 
     dialogRef.mutate({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -196,6 +196,14 @@
 </div>
 
 <div class="block">
+  <h2>Reset location of a modal</h2>
+
+  <button (click)="openResetLocationDialog(config.value)">
+    Open a dialog that you reset the location of
+  </button>
+</div>
+
+<div class="block">
   <h2>Pass data to the dialog and get a result</h2>
   <p>You can pass any data to your dialog:</p>
   <form [formGroup]="data">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { DialogConfig, DialogRef, DialogService } from '@ngneat/dialog';
 
 import { TestDialogComponent } from './test-dialog.component';
 import { ConfirmationModalComponent } from './custom-confirm-dialog.component';
+import { ResetLocationDialogComponent } from './reset-location-dialog.component';
 
 @Component({
   selector: 'app-root',
@@ -189,6 +190,10 @@ export class AppComponent {
         })
         .afterClosed$.pipe(tap(close => (this.closeOnce = !close)))
     );
+  }
+
+  openResetLocationDialog(config: DialogConfig) {
+    this.openDialog(ResetLocationDialogComponent, { ...config, draggable: true });
   }
 
   openDialogWithCustomData(compOrTemplate: Type<any> | TemplateRef<any>, data: object, config: DialogConfig) {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,9 +6,10 @@ import { DialogModule } from '@ngneat/dialog';
 import { AppComponent } from './app.component';
 import { TestDialogComponent } from './test-dialog.component';
 import { ConfirmationModalComponent } from './custom-confirm-dialog.component';
+import { ResetLocationDialogComponent } from './reset-location-dialog.component';
 
 @NgModule({
-  declarations: [AppComponent, TestDialogComponent, ConfirmationModalComponent],
+  declarations: [AppComponent, TestDialogComponent, ResetLocationDialogComponent, ConfirmationModalComponent],
   imports: [
     BrowserModule,
     ReactiveFormsModule,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Resetting the location of a dialog now also works with the offset. This parameter wasn't passed through at all before. So the offset was also never applied.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
