### PR TITLE
fix: expose return type of dialog ref

### DIFF
--- a/projects/ngneat/dialog/src/lib/dialog-ref.ts
+++ b/projects/ngneat/dialog/src/lib/dialog-ref.ts
@@ -17,7 +17,7 @@ export abstract class DialogRef<
   public data: Data;
 
   public backdropClick$: Observable<MouseEvent>;
-  public afterClosed$: Observable<Result>;
+  public afterClosed$: Observable<Result | undefined>;
 
   abstract close(result?: Result): void;
   abstract beforeClose(guard: GuardFN<Result>): void;
@@ -53,10 +53,10 @@ export class InternalDialogRef extends DialogRef {
 
   canClose(result: unknown): Observable<boolean> {
     const guards$ = this.beforeCloseGuards
-      .map(guard => guard(result))
-      .filter(value => value !== undefined && value !== true)
-      .map(value => {
-        return typeof value === 'boolean' ? of(value) : from(value).pipe(filter(canClose => !canClose));
+      .map((guard) => guard(result))
+      .filter((value) => value !== undefined && value !== true)
+      .map((value) => {
+        return typeof value === 'boolean' ? of(value) : from(value).pipe(filter((canClose) => !canClose));
       });
 
     return merge(...guards$).pipe(defaultIfEmpty(true), first());

--- a/projects/ngneat/dialog/src/lib/dialog.service.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.service.ts
@@ -15,7 +15,7 @@ import { DialogRef, InternalDialogRef } from './dialog-ref';
 import { DialogComponent } from './dialog.component';
 import { DragOffset } from './draggable.directive';
 import { DIALOG_CONFIG, DIALOG_DOCUMENT_REF, GLOBAL_DIALOG_CONFIG, NODES_TO_INSERT } from './providers';
-import { AttachOptions, DialogConfig, ExtractData, GlobalDialogConfig, OpenParams } from './types';
+import { AttachOptions, DialogConfig, ExtractData, ExtractResult, GlobalDialogConfig, OpenParams } from './types';
 import { map } from 'rxjs/operators';
 
 const OVERFLOW_HIDDEN_CLASS = 'ngneat-dialog-hidden';
@@ -55,7 +55,7 @@ export class DialogService {
   open<C extends Type<any>>(
     component: C,
     config?: Partial<DialogConfig<ExtractData<InstanceType<C>>>>
-  ): DialogRef<ExtractData<InstanceType<C>>>;
+  ): DialogRef<ExtractData<InstanceType<C>>, ExtractResult<InstanceType<C>>>;
   open(componentOrTemplate: any, config: Partial<DialogConfig<any>> = {}): DialogRef {
     const mergedConfig = this.mergeConfig(config);
     mergedConfig.onOpen?.();

--- a/projects/ngneat/dialog/src/lib/specs/types.spec.ts
+++ b/projects/ngneat/dialog/src/lib/specs/types.spec.ts
@@ -1,0 +1,43 @@
+import { DialogRef } from '../dialog-ref';
+import { ExtractData, ExtractResult } from '../types';
+
+// Helper functions
+
+type Expect<T extends true> = T;
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+
+// Type tests for ExtractData helper
+
+type WellDefinedStringData = ExtractData<{ ref: DialogRef<string> }>;
+type WellDefinedObjectData = ExtractData<{ ref: DialogRef<{ key: string }> }>;
+type WellDefinedUnknownData = ExtractData<{ ref: DialogRef<unknown> }>;
+type WellDefinedAnyData = ExtractData<{ ref: DialogRef<any> }>;
+type ImplicitAnyData = ExtractData<{ ref: DialogRef }>;
+type MissingRefData = ExtractData<{}>;
+
+type dataCases = [
+  Expect<Equal<WellDefinedStringData, string>>,
+  Expect<Equal<WellDefinedObjectData, { key: string }>>,
+  Expect<Equal<WellDefinedUnknownData, unknown>>,
+  Expect<Equal<WellDefinedAnyData, any>>,
+  Expect<Equal<ImplicitAnyData, any>>,
+  Expect<Equal<MissingRefData, any>>
+];
+
+// Type tests for ExtractResult helper
+
+type WellDefinedStringResult = ExtractResult<{ ref: DialogRef<unknown, string> }>;
+type WellDefinedObjectResult = ExtractResult<{ ref: DialogRef<unknown, { key: string }> }>;
+type WellDefinedUnknownResult = ExtractResult<{ ref: DialogRef<unknown, unknown> }>;
+type WellDefinedAnyResult = ExtractResult<{ ref: DialogRef<unknown, any> }>;
+type ImplicitAnyResult = ExtractResult<{ ref: DialogRef<unknown> }>;
+type MissingRefResult = ExtractResult<{}>;
+
+type resultCases = [
+  Expect<Equal<WellDefinedStringResult, string | undefined>>,
+  Expect<Equal<WellDefinedObjectResult, { key: string } | undefined>>,
+  Expect<Equal<WellDefinedUnknownResult, unknown | undefined>>,
+  Expect<Equal<WellDefinedAnyResult, any | undefined>>,
+  Expect<Equal<ImplicitAnyResult, any | undefined>>,
+  Expect<Equal<MissingRefResult, any | undefined>>
+];

--- a/projects/ngneat/dialog/src/lib/types.ts
+++ b/projects/ngneat/dialog/src/lib/types.ts
@@ -45,7 +45,16 @@ export type ExtractRefProp<T> = NonNullable<
   }[keyof T]
 >;
 
-export type ExtractData<T> = T[ExtractRefProp<T>] extends DialogRef<infer Data> ? Data : never;
+export type ExtractData<T> = ExtractRefProp<T> extends never
+  ? any
+  : T[ExtractRefProp<T>] extends DialogRef<infer Data>
+  ? Data
+  : never;
+export type ExtractResult<T> = ExtractRefProp<T> extends never
+  ? any
+  : T[ExtractRefProp<T>] extends DialogRef<any, infer Result>
+  ? Result
+  : never;
 
 export interface OpenParams {
   config: DialogConfig;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Fix for typing
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #86

## What is the new behavior?

Dialogs that do have a result type defined will now expose said type in the `afterClosed$` observable, instead of an `any` Observable.

## Does this PR introduce a breaking change?

```
[x] Yes (but only in the typings, not on run-time)
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Typing changes might be incompatible resulting in failed builds, this change should not introduce any runtime changes.
Dialogs that do have a result type defined will now expose said type in the `afterClosed$` observable, instead of an `any` Observable.
**Edit:**
This behavior has been updated in 6c0891d, components without a `DialogRef` property, or with a `DialogRef` property that does not have a `Result` defined, will now get a return type of `any` assigned. This is the same as the current behavior.


## Other information

New tests for typing helpers have been introduced in this PR.
