### PR TITLE
fix(draggable): move target instead of handle

### DIFF
--- a/projects/ngneat/dialog/src/lib/draggable.directive.ts
+++ b/projects/ngneat/dialog/src/lib/draggable.directive.ts
@@ -138,7 +138,7 @@ export class DialogDraggableDirective implements AfterViewInit, OnChanges, OnDes
       this.zone.runOutsideAngular(() => {
         requestAnimationFrame(() => {
           const transform = `translate(${this.translateX}px, ${this.translateY}px)`;
-          this.handle.style.setProperty('transform', transform);
+          this.target.style.setProperty('transform', transform);
         });
       });
     }


### PR DESCRIPTION
since the handle element is a child of the target element, it still gets moved as expected. this was probably more of a typo than an actual bug.

fixes #84

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~ n/a

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
tl;dr: dragging a dialog handle only moves the handle and leaves the dialog in place.
Issue Number: #84 

## What is the new behavior?
dragging the dialog handle moves the whole dialog (including the handle), as expected

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
