### PR TITLE
feat: allow to reset config once dialog has been opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ dialogRef.resetDrag();
 dialogRef.resetDrag({ x: 100, y: 0 });
 ```
 
+- `updateDialogConfig` - A method that can be called to update dialog config once it has been opened. All config properties can be updated despite data:
+
+```ts
+dialogRef.updateDialogConfig({draggable: true});
+```
+
 - `beforeClose` - A guard that should return a `boolean`, an `observable`, or a `promise` indicating whether the modal can be closed:
 
 ```ts

--- a/projects/ngneat/dialog/src/lib/dialog-ref.ts
+++ b/projects/ngneat/dialog/src/lib/dialog-ref.ts
@@ -2,7 +2,7 @@ import { ComponentRef, TemplateRef } from '@angular/core';
 import { from, merge, Observable, of, Subject } from 'rxjs';
 import { defaultIfEmpty, filter, first } from 'rxjs/operators';
 
-import { JustProps } from './types';
+import { DialogConfig, JustProps } from './types';
 import { DragOffset } from './draggable.directive';
 
 type GuardFN<R> = (result?: R) => Observable<boolean> | Promise<boolean> | boolean;
@@ -36,6 +36,7 @@ export class InternalDialogRef extends DialogRef {
 
   onClose: (result?: unknown) => void;
   onReset: (offset?: DragOffset) => void;
+  updateDialogConfig: (dialogConfig: Partial<Omit<DialogConfig, 'data'>>) => void;
 
   close(result?: unknown): void {
     this.canClose(result)

--- a/projects/ngneat/dialog/src/lib/dialog.service.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.service.ts
@@ -10,13 +10,12 @@ import {
   Type,
   ViewRef,
 } from '@angular/core';
-import { BehaviorSubject, startWith, Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { DialogRef, InternalDialogRef } from './dialog-ref';
 import { DialogComponent } from './dialog.component';
 import { DragOffset } from './draggable.directive';
 import { DIALOG_CONFIG, DIALOG_DOCUMENT_REF, GLOBAL_DIALOG_CONFIG, NODES_TO_INSERT } from './providers';
 import { AttachOptions, DialogConfig, ExtractData, ExtractResult, GlobalDialogConfig, OpenParams } from './types';
-import { map } from 'rxjs/operators';
 
 const OVERFLOW_HIDDEN_CLASS = 'ngneat-dialog-hidden';
 
@@ -161,6 +160,7 @@ export class DialogService {
         backdropClick$: null,
         beforeCloseGuards: null,
         onReset: null,
+        updateDialogConfig: null,
       });
 
       hooks.after.next(result);
@@ -174,6 +174,10 @@ export class DialogService {
       dialog.instance.reset(offset);
     };
 
+    const updateDialogConfig = (dialogConfig: Partial<Omit<DialogConfig, 'data'>>) => {
+      dialog.instance.updateDialogConfig(dialogConfig);
+    };
+
     dialogRef.mutate({
       id: config.id,
       data: config.data,
@@ -181,6 +185,7 @@ export class DialogService {
       onClose,
       afterClosed$: hooks.after.asObservable(),
       onReset,
+      updateDialogConfig,
     });
 
     container.appendChild(dialog.location.nativeElement);

--- a/projects/ngneat/dialog/src/lib/specs/dialog.component.spec.ts
+++ b/projects/ngneat/dialog/src/lib/specs/dialog.component.spec.ts
@@ -199,6 +199,34 @@ describe('DialogComponent', () => {
     });
   });
 
+  describe('config update', () => {
+    beforeEach(() => {
+      spectator = createComponent(withConfig({ enableClose: true }));
+    });
+
+    it('should properly update draggable in config', () => {
+      expect(spectator.component.config.draggable).toBeFalse();
+      spectator.component.updateDialogConfig({ draggable: true });
+      expect(spectator.component.config.draggable).toBeTruthy();
+    });
+
+    it('should properly update size and id in config', () => {
+      expect(spectator.component.config.id).toBe('test');
+      expect(spectator.component.config.size).toBe('md');
+      spectator.component.updateDialogConfig({ size: 'lg', id: 'unique' });
+      expect(spectator.component.config.id).toBe('unique');
+      expect(spectator.component.config.size).toBe('lg');
+    });
+
+    it('should properly update width and enableClose in config', () => {
+      expect(spectator.component.config.enableClose).toBeTruthy();
+      expect(spectator.component.config.width).toBe(undefined);
+      spectator.component.updateDialogConfig({ width: '200px', enableClose: false });
+      expect(spectator.component.config.enableClose).toBeFalse();
+      expect(spectator.component.config.width).toBe('200px');
+    });
+  });
+
   describe('when draggable is enabled', () => {
     beforeEach(() => (spectator = createComponent(withConfig({ draggable: true }))));
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

We are not allowed to override config once it has been opened

Issue Number: #41 

## What is the new behavior?

We can override config of the dialog after opening
