### PR TITLE
feat(config): split up backdrop+escape enableClose

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,10 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideDialogConfig({
       closeButton: boolean,
-      enableClose: boolean | 'onlyLastStrategy',
+      enableClose: boolean | 'onlyLastStrategy' | {
+        escape: boolean | 'onlyLastStrategy',
+        backdrop: boolean | 'onlyLastStrategy',
+      },
       backdrop: boolean,
       resizable: boolean,
       draggable: boolean,
@@ -283,7 +286,11 @@ this.dialog.open(compOrTemplate, {
 ```
 
 ### Enable close
-The `enableClose` property can be configured for each dialog. 
+The `enableClose` property can be configured for each dialog.
+It can either be an object with the keys `escape` and `backdrop` for more granular control,
+or one of the values described below directly.
+The latter will apply the set value to both close triggers (escape and backdrop).
+
 If set to `true`, clicking on the backdrop or pressing the escape key will close the modal. 
 If set to `false`, this behavior will be disabled.
 

--- a/projects/ngneat/dialog/src/lib/dialog.component.ts
+++ b/projects/ngneat/dialog/src/lib/dialog.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule, DOCUMENT } from '@angular/common';
 import { Component, ElementRef, inject, Inject, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { fromEvent, merge, Subject } from 'rxjs';
-import { filter, takeUntil } from 'rxjs/operators';
+import { filter, map, takeUntil } from 'rxjs/operators';
 import { InternalDialogRef } from './dialog-ref';
 import { DialogService } from './dialog.service';
 import { coerceCssPixelValue } from './dialog.utils';
@@ -105,23 +105,32 @@ export class DialogComponent implements OnInit, OnDestroy {
 
     backdropClick$.pipe(takeUntil(this.destroy$)).subscribe(this.dialogRef.backdropClick$);
 
-    if (this.config.enableClose) {
-      merge(
-        fromEvent<KeyboardEvent>(this.document.body, 'keyup').pipe(filter(({ key }) => key === 'Escape')),
-        backdropClick$
+    // backwards compatibility with non-split option
+    const closeConfig =
+      typeof this.config.enableClose === 'object'
+        ? this.config.enableClose
+        : {
+            escape: this.config.enableClose,
+            backdrop: this.config.enableClose,
+          };
+    merge(
+      fromEvent<KeyboardEvent>(this.document.body, 'keyup').pipe(
+        filter(({ key }) => key === 'Escape'),
+        map(() => closeConfig.escape)
+      ),
+      backdropClick$.pipe(map(() => closeConfig.backdrop))
+    )
+      .pipe(
+        takeUntil(this.destroy$),
+        filter((strategy) => {
+          if (!strategy) return false;
+          if (strategy === 'onlyLastStrategy') {
+            return this.dialogService.isLastOpened(this.config.id);
+          }
+          return true;
+        })
       )
-        .pipe(
-          takeUntil(this.destroy$),
-          filter(() => {
-            if (this.config.enableClose === 'onlyLastStrategy') {
-              return this.dialogService.isLastOpened(this.config.id);
-            }
-
-            return true;
-          })
-        )
-        .subscribe(() => this.closeDialog());
-    }
+      .subscribe(() => this.closeDialog());
 
     // `dialogElement` is resolved at this point
     // And here is where dialog finally will be placed

--- a/projects/ngneat/dialog/src/lib/providers.ts
+++ b/projects/ngneat/dialog/src/lib/providers.ts
@@ -26,7 +26,10 @@ export function defaultGlobalConfig(): Partial<GlobalDialogConfig & DialogConfig
     container: inject(DIALOG_DOCUMENT_REF).body,
     backdrop: true,
     closeButton: true,
-    enableClose: true,
+    enableClose: {
+      backdrop: true,
+      escape: true,
+    },
     draggable: false,
     dragConstraint: 'none',
     resizable: false,

--- a/projects/ngneat/dialog/src/lib/types.ts
+++ b/projects/ngneat/dialog/src/lib/types.ts
@@ -3,6 +3,7 @@ import { DialogRef, InternalDialogRef } from './dialog-ref';
 
 type Sizes = 'sm' | 'md' | 'lg' | 'fullScreen' | string;
 export type DragConstraint = 'none' | 'bounce' | 'constrain';
+export type CloseStrategy = boolean | 'onlyLastStrategy';
 
 export interface GlobalDialogConfig {
   sizes: Partial<
@@ -23,7 +24,12 @@ export interface GlobalDialogConfig {
   closeButton: boolean;
   draggable: boolean;
   dragConstraint: DragConstraint;
-  enableClose: boolean | 'onlyLastStrategy';
+  enableClose:
+    | CloseStrategy
+    | {
+        escape: CloseStrategy;
+        backdrop: CloseStrategy;
+      };
   resizable: boolean;
   width: string | number;
   minWidth: string | number;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -57,10 +57,16 @@
       <label>Close Button</label>
       <input type="checkbox" formControlName="closeButton" />
     </div>
-    <div>
-      <label>Enable Close ❌</label>
-      <input type="checkbox" formControlName="enableClose" />
-    </div>
+    <ng-container formGroupName="enableClose">
+      <div>
+        <label>Escape to Close ❌</label>
+        <input type="checkbox" formControlName="escape" />
+      </div>
+      <div>
+        <label>Backdrop to Close ❌</label>
+        <input type="checkbox" formControlName="backdrop" />
+      </div>
+    </ng-container>
   </form>
 
   <p *ngIf="backDropClicked">You've clicked the backdrop 👏</p>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,7 +28,10 @@ export class AppComponent {
     id: [''],
     height: [''],
     width: [''],
-    enableClose: [true],
+    enableClose: this.fb.group({
+      escape: [true],
+      backdrop: [true],
+    }),
     closeButton: [true],
     backdrop: [true],
     resizable: [false],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] optional: Playground has been adjusted for more powerful config format

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The config option `enableClose` applies to both closing using the escape key and clicking on the backdrop

Issue Number: #34 

## What is the new behavior?

This allows you to only close the dialog on escape press but not backdrop click, or vice versa.
```ts
{
  enableClose: {
    backdrop: false,
    escape: true,
  }
}
```
This implementation is backwards compatible, old values are treated just like before.
```ts
{
  enableClose: false
}
// equivalent
{
  enableClose: {
    backdrop: false,
    escape: false,
  }
}
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Currently, for the "object syntax", all (both) keys are required because that seemed reasonable to me.
the other option would have been to make them default to true, like the old enableClose does.
let me know what you think!

I haven't adjusted the tests yet because I've never done any testing with angular / jasmine / ...
I'd imagine we want a kind of matrix test on top of the [existing ones](https://github.com/ngneat/dialog/blob/master/projects/ngneat/dialog/src/lib/specs/dialog.component.spec.ts#L123-L282).

I'll try to look into that, but feel free comment on the feature/code change already - no need to think about tests if this is not an implementation you would merge :b

closes #34 