### PR TITLE
fix: allow nullable values again

### DIFF
--- a/libs/dialog/src/lib/types.ts
+++ b/libs/dialog/src/lib/types.ts
@@ -59,10 +59,11 @@ export type JustProps<T extends object> = Pick<
   }[keyof T]
 >;
 
-export type ExtractRefProp<T> = NonNullable<
+export type ExtractRefProp<T> = Exclude<
   {
     [P in keyof T]: T[P] extends DialogRef ? P : never;
-  }[keyof T]
+  }[keyof T],
+  undefined | null
 >;
 
 export type ExtractData<T> = ExtractRefProp<T> extends never


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features) - no tests added as this PR only updates types
- [x] Docs have been added / updated (for bug fixes / features) - no new docs required

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue #81 is reintroduced when upgrading to TS 5.4+.

Issue Number: #119 

## What is the new behavior?

The updated typing allows the same behavior we expect today on TS versions below 5.4.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
Angular 18 requires TS 5.4+ which [breaks the NonNullable type](https://github.com/microsoft/TypeScript/issues/56644).

This PR replaces NonNullable with Exclude to allow correct typing of ExtractRefProp and fix the issue where opening dialogs containing undefined values throws TS2769 when trying to set the data property.